### PR TITLE
Introduce error guard with 6 tries and successful exec reset

### DIFF
--- a/apps/core/jest-resolver.cjs
+++ b/apps/core/jest-resolver.cjs
@@ -1,0 +1,15 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+module.exports = (request, options) => {
+    if (request.startsWith('.') && request.endsWith('.mjs')) {
+        const mtsRequest = request.replace(/\.mjs$/, '.mts');
+        const candidatePath = path.resolve(options.basedir, mtsRequest);
+
+        if (fs.existsSync(candidatePath)) {
+            return options.defaultResolver(mtsRequest, options);
+        }
+    }
+
+    return options.defaultResolver(request, options);
+};

--- a/apps/core/jest.config.mjs
+++ b/apps/core/jest.config.mjs
@@ -2,9 +2,8 @@
 export default {
     preset: 'ts-jest/presets/default-esm',
     testEnvironment: 'node',
-    moduleNameMapper: {
-        '^(\\.{1,2}/.*)\\.mjs$': '$1.mts',
-    },
+    moduleFileExtensions: ['mts', 'ts', 'mjs', 'js', 'json'],
+    resolver: './jest-resolver.cjs',
     transform: {
         '^.+\\.mts$': [
             'ts-jest',

--- a/apps/core/src/trpc/routers/converse/blocks.mts
+++ b/apps/core/src/trpc/routers/converse/blocks.mts
@@ -21,6 +21,7 @@ export const userBlockToPayload = (block: TUserBlock): unknown =>
 
 export const countConsecutiveEditFailures = (
     blocks: readonly TSelectableBlock[],
+    currentBlocks: readonly TUserBlock[] = [],
 ): number => {
     let count = 0;
 
@@ -41,25 +42,38 @@ export const countConsecutiveEditFailures = (
         {toolUse: new Map(), toolResult: []},
     );
 
-    // Walk backwards through tool_result blocks
-    const sortedResults = [...blocksByType.toolResult].sort(
-        (a, b) =>
-            b.created_at.getTime() - a.created_at.getTime() ||
-            b.id.localeCompare(a.id),
-    );
+    const orderedResults = [
+        ...blocksByType.toolResult.map((block) => {
+            const payload = block.payload as {
+                execution_identifier: string;
+                error: string | null;
+            };
 
-    for (const resultBlock of sortedResults) {
-        const payload = resultBlock.payload as {
-            execution_identifier: string;
-            error: string | null;
-        };
+            return {
+                execution_identifier: payload.execution_identifier,
+                error: payload.error,
+            };
+        }),
+        ...currentBlocks
+            .filter(
+                (block): block is Extract<TUserBlock, {type: 'execution_result'}> =>
+                    block.type === 'execution_result',
+            )
+            .map((block) => ({
+                execution_identifier: block.execution_identifier,
+                error: block.error,
+            })),
+    ];
 
-        if (!payload.error) {
+    // Walk backwards through tool_result blocks, including the current user turn.
+    for (let i = orderedResults.length - 1; i >= 0; i--) {
+        const resultBlock = orderedResults[i];
+        if (!resultBlock.error) {
             break; // Success found, stop counting
         }
 
         const toolUseBlock = blocksByType.toolUse.get(
-            payload.execution_identifier,
+            resultBlock.execution_identifier,
         );
         if (!toolUseBlock) {
             break;

--- a/apps/core/src/trpc/routers/converse/guards.mts
+++ b/apps/core/src/trpc/routers/converse/guards.mts
@@ -2,7 +2,11 @@ import {TRPCError} from '@trpc/server';
 import type {Kysely} from 'kysely';
 import type {TDatabase} from '#core/db/types.mjs';
 import type {TSelectableBlock, TSelectableTurn} from '#core/db/types.mjs';
-import {MAX_AGENT_TURNS} from './schemas.mjs';
+import type {TUserBlock} from './schemas.mjs';
+import {
+    MAX_AGENT_TURNS,
+    MAX_CONSECUTIVE_FAILED_EXECUTION_TURNS,
+} from './schemas.mjs';
 
 // ── Block User Turns While Agent Is Processing ──────────────
 
@@ -45,40 +49,141 @@ export const guardAgentProcessing = async (
 
 // ── Agent Turn Counting ─────────────────────────────────────
 
+type TRunSegment = {
+    readonly turns: readonly TSelectableTurn[];
+    readonly blocks: readonly TSelectableBlock[];
+};
+
 type TTurnBudget = {
     readonly agentTurnCount: number;
     readonly turnsRemaining: number;
     readonly isForceStop: boolean;
 };
 
-export const countAgentTurnsSinceLastUserTurn = (
+type TFailedExecutionBudget = {
+    readonly failedExecutionTurnCount: number;
+    readonly turnsRemaining: number;
+    readonly isForceStop: boolean;
+};
+
+const buildBlocksByTurnId = (
+    blocks: readonly TSelectableBlock[],
+): Readonly<Record<string, readonly TSelectableBlock[]>> =>
+    blocks.reduce<Record<string, readonly TSelectableBlock[]>>((acc, block) => {
+        const existing = acc[block.turn_id] ?? [];
+        return {...acc, [block.turn_id]: [...existing, block]};
+    }, {});
+
+const isStoredTrueUserTurn = (blocks: readonly TSelectableBlock[]): boolean =>
+    blocks.length > 0 && blocks.every((block) => block.type === 'text');
+
+const isCurrentTrueUserTurn = (blocks: readonly TUserBlock[]): boolean =>
+    blocks.length > 0 && blocks.every((block) => block.type === 'text');
+
+const isStoredFailedExecutionTurn = (
+    blocks: readonly TSelectableBlock[],
+): boolean =>
+    blocks.length > 0 &&
+    blocks.every((block) => block.type === 'tool_result') &&
+    blocks.every((block) => {
+        const payload = block.payload as {error: string | null};
+        return payload.error !== null;
+    });
+
+const isCurrentFailedExecutionTurn = (blocks: readonly TUserBlock[]): boolean =>
+    blocks.length > 0 &&
+    blocks.every((block) => block.type === 'execution_result') &&
+    blocks.every((block) => block.error !== null);
+
+const hasSuccessfulExecution = (blocks: readonly TUserBlock[]): boolean =>
+    blocks.some(
+        (block) => block.type === 'execution_result' && block.error === null,
+    );
+
+export const getRunSegmentSinceLastTrueUserTurn = (
     isTrueUserTurn: boolean,
     existingTurns: readonly TSelectableTurn[],
     existingBlocks: readonly TSelectableBlock[],
-): TTurnBudget => {
-    const lastTrueUserTurnIdx = isTrueUserTurn
-        ? -1 // current turn is a new user request; budget starts fresh
-        : existingTurns.findLastIndex((turn) => {
-              if (turn.actor !== 'user') {
-                  return false;
-              }
-              const turnBlocks = existingBlocks.filter(
-                  (b) => b.turn_id === turn.id,
-              );
-              return turnBlocks.every((b) => b.type === 'text');
-          });
+): TRunSegment => {
+    if (isTrueUserTurn) {
+        return {turns: [], blocks: []};
+    }
 
-    const agentTurnCount =
+    const blocksByTurnId = buildBlocksByTurnId(existingBlocks);
+    const lastTrueUserTurnIdx = existingTurns.findLastIndex((turn) => {
+        if (turn.actor !== 'user') {
+            return false;
+        }
+
+        return isStoredTrueUserTurn(blocksByTurnId[turn.id] ?? []);
+    });
+
+    const turns =
         lastTrueUserTurnIdx === -1
-            ? 0
-            : existingTurns
-                  .slice(lastTrueUserTurnIdx)
-                  .filter((t) => t.actor === 'assistant').length;
+            ? existingTurns
+            : existingTurns.slice(lastTrueUserTurnIdx + 1);
+    const turnIds = new Set(turns.map((turn) => turn.id));
+    const blocks = existingBlocks.filter((block) => turnIds.has(block.turn_id));
 
+    return {turns, blocks};
+};
+
+export const countAgentTurnsSinceLastUserTurn = (
+    runSegmentTurns: readonly TSelectableTurn[],
+): TTurnBudget => {
+    const agentTurnCount = runSegmentTurns.filter(
+        (turn) => turn.actor === 'assistant',
+    ).length;
     const turnsRemaining = MAX_AGENT_TURNS - agentTurnCount;
 
     return {
         agentTurnCount,
+        turnsRemaining,
+        isForceStop: turnsRemaining <= 0,
+    };
+};
+
+export const countConsecutiveFailedExecutionTurns = (
+    runSegmentTurns: readonly TSelectableTurn[],
+    runSegmentBlocks: readonly TSelectableBlock[],
+    currentBlocks: readonly TUserBlock[],
+): TFailedExecutionBudget => {
+    if (
+        isCurrentTrueUserTurn(currentBlocks) ||
+        hasSuccessfulExecution(currentBlocks) ||
+        !isCurrentFailedExecutionTurn(currentBlocks)
+    ) {
+        return {
+            failedExecutionTurnCount: 0,
+            turnsRemaining: MAX_CONSECUTIVE_FAILED_EXECUTION_TURNS,
+            isForceStop: false,
+        };
+    }
+
+    const blocksByTurnId = buildBlocksByTurnId(runSegmentBlocks);
+    let priorFailedExecutionTurnCount = 0;
+
+    for (let i = runSegmentTurns.length - 1; i >= 0; i--) {
+        const turn = runSegmentTurns[i];
+
+        if (turn.actor !== 'user') {
+            continue;
+        }
+
+        const turnBlocks = blocksByTurnId[turn.id] ?? [];
+        if (!isStoredFailedExecutionTurn(turnBlocks)) {
+            break;
+        }
+
+        priorFailedExecutionTurnCount++;
+    }
+
+    const failedExecutionTurnCount = priorFailedExecutionTurnCount + 1;
+    const turnsRemaining =
+        MAX_CONSECUTIVE_FAILED_EXECUTION_TURNS - failedExecutionTurnCount;
+
+    return {
+        failedExecutionTurnCount,
         turnsRemaining,
         isForceStop: turnsRemaining <= 0,
     };

--- a/apps/core/src/trpc/routers/converse/index.mts
+++ b/apps/core/src/trpc/routers/converse/index.mts
@@ -8,6 +8,7 @@ import {
     DB_MODEL,
     MAX_TOKENS,
     MAX_CONSECUTIVE_EDIT_FAILURES,
+    MAX_CONSECUTIVE_FAILED_EXECUTION_TURNS,
     MAX_AGENT_TURNS,
     WRITE_AND_RUN_JS_TOOL,
     EDIT_AND_RUN_JS_TOOL,
@@ -31,6 +32,8 @@ import {
 import {
     guardAgentProcessing,
     countAgentTurnsSinceLastUserTurn,
+    countConsecutiveFailedExecutionTurns,
+    getRunSegmentSinceLastTrueUserTurn,
 } from './guards.mjs';
 
 // ── Router ──────────────────────────────────────────────────
@@ -129,13 +132,27 @@ export const converseRouter = router({
                           .execute()
                     : [];
 
-            // 4. Count agent turns
-            const {agentTurnCount, turnsRemaining, isForceStop} =
-                countAgentTurnsSinceLastUserTurn(
-                    isTrueUserTurn,
-                    existingTurns,
-                    existingBlocks,
+            const runSegment = getRunSegmentSinceLastTrueUserTurn(
+                isTrueUserTurn,
+                existingTurns,
+                existingBlocks,
+            );
+
+            // 4. Count execution budgets
+            const agentTurnBudget = countAgentTurnsSinceLastUserTurn(
+                runSegment.turns,
+            );
+            const failedExecutionTurnBudget =
+                countConsecutiveFailedExecutionTurns(
+                    runSegment.turns,
+                    runSegment.blocks,
+                    input.blocks,
                 );
+            const forceStopReason = agentTurnBudget.isForceStop
+                ? ('max_agent_turns' as const)
+                : failedExecutionTurnBudget.isForceStop
+                  ? ('failed_execution_turns' as const)
+                  : null;
 
             // 5. Find last code block for editing
             const lastCodeBlock = [...existingBlocks]
@@ -151,8 +168,12 @@ export const converseRouter = router({
                 : null;
 
             // 6. Check consecutive edit failures
-            const editFailures = countConsecutiveEditFailures(existingBlocks);
+            const editFailures = countConsecutiveEditFailures(
+                runSegment.blocks,
+                input.blocks,
+            );
             const shouldDisableEdit =
+                forceStopReason === null &&
                 editFailures >= MAX_CONSECUTIVE_EDIT_FAILURES;
 
             // 7. Build messages
@@ -172,12 +193,12 @@ export const converseRouter = router({
             const currentUserMessage: MessageParam = {
                 role: 'user',
                 content:
-                    !isForceStop && agentTurnCount > 0
+                    forceStopReason === null && !isTrueUserTurn
                         ? [
                               ...currentUserContent,
                               {
                                   type: 'text' as const,
-                                  text: `[System: You have ${turnsRemaining} execution turn(s) remaining.]`,
+                                  text: `[System: You have ${failedExecutionTurnBudget.turnsRemaining} consecutive failed execution turn(s) remaining before you must stop if failures continue.]`,
                               },
                           ]
                         : currentUserContent,
@@ -212,20 +233,20 @@ export const converseRouter = router({
                 contextSection + systemPromptBase;
 
             const dynamicSystemPrompt =
-                `\n\n<turn_budget>\nYou have a maximum of ${MAX_AGENT_TURNS} execution turns to fulfill the user's request. Budget your turns carefully: explore and plan early, execute decisively, and verify before your turns run out.\n</turn_budget>` +
-                (shouldDisableEdit && !isForceStop
+                `\n\n<execution_limits>\nYou have a maximum of ${MAX_AGENT_TURNS} total execution turns to fulfill a single user request. This is a hard backstop.\nYou also have a maximum of ${MAX_CONSECUTIVE_FAILED_EXECUTION_TURNS} consecutive failed execution turns. A failed execution turn is a follow-up turn where every execution result is an error.\nAny successful execution result resets the consecutive failed execution turn counter to 0.\nBudget your attempts carefully. If you exhaust either limit, you must stop using tools and apologize to the user.\n</execution_limits>` +
+                (shouldDisableEdit && forceStopReason === null
                     ? `\n\n<important_notice>\nEditing has failed ${editFailures} times consecutively. The edit_and_run_js tool has been disabled. You MUST use write_and_run_js to write fresh code.\n</important_notice>`
                     : '');
 
             // 9. Build tools + apply force-stop + cache breakpoints
-            const tools: Tool[] = isForceStop
+            const tools: Tool[] = forceStopReason
                 ? []
                 : shouldDisableEdit
                   ? [WRITE_AND_RUN_JS_TOOL]
                   : [WRITE_AND_RUN_JS_TOOL, EDIT_AND_RUN_JS_TOOL];
 
-            if (isForceStop) {
-                applyForceStop(messages);
+            if (forceStopReason) {
+                applyForceStop(messages, forceStopReason);
             }
 
             const cachedMessages = markLastMessageForCaching(messages);

--- a/apps/core/src/trpc/routers/converse/loop-controls.test.mts
+++ b/apps/core/src/trpc/routers/converse/loop-controls.test.mts
@@ -1,0 +1,382 @@
+import type {MessageParam} from '@anthropic-ai/sdk/resources/messages';
+import type {TSelectableBlock, TSelectableTurn} from '#core/db/types.mjs';
+import {MAX_AGENT_TURNS, MAX_CONSECUTIVE_EDIT_FAILURES, MAX_CONSECUTIVE_FAILED_EXECUTION_TURNS, type TUserBlock} from './schemas.mjs';
+import {countConsecutiveEditFailures} from './blocks.mjs';
+import {
+    countAgentTurnsSinceLastUserTurn,
+    countConsecutiveFailedExecutionTurns,
+    getRunSegmentSinceLastTrueUserTurn,
+} from './guards.mjs';
+import {applyForceStop} from './messages.mjs';
+
+const CONVERSATION_ID = 'conversation-1';
+
+const makeTurn = (
+    id: string,
+    actor: 'user' | 'assistant',
+    createdAtMs: number,
+): TSelectableTurn => ({
+    id,
+    conversation_id: CONVERSATION_ID,
+    actor,
+    created_at: new Date(createdAtMs),
+});
+
+const makeTextBlock = (
+    id: string,
+    turnId: string,
+    message: string,
+    createdAtMs: number,
+): TSelectableBlock => ({
+    id,
+    conversation_id: CONVERSATION_ID,
+    turn_id: turnId,
+    type: 'text',
+    payload: {message},
+    created_at: new Date(createdAtMs),
+});
+
+const makeToolUseBlock = (
+    id: string,
+    turnId: string,
+    executionIdentifier: string,
+    toolName: string,
+    createdAtMs: number,
+): TSelectableBlock => ({
+    id,
+    conversation_id: CONVERSATION_ID,
+    turn_id: turnId,
+    type: 'tool_use',
+    payload: {
+        execution_identifier: executionIdentifier,
+        tool_name: toolName,
+        description: toolName,
+        code: `// ${executionIdentifier}`,
+    },
+    created_at: new Date(createdAtMs),
+});
+
+const makeToolResultBlock = (
+    id: string,
+    turnId: string,
+    executionIdentifier: string,
+    error: string | null,
+    createdAtMs: number,
+): TSelectableBlock => ({
+    id,
+    conversation_id: CONVERSATION_ID,
+    turn_id: turnId,
+    type: 'tool_result',
+    payload: {
+        execution_identifier: executionIdentifier,
+        result: 'result',
+        error,
+    },
+    created_at: new Date(createdAtMs),
+});
+
+const makeExecutionResult = (
+    executionIdentifier: string,
+    error: string | null,
+): TUserBlock => ({
+    type: 'execution_result',
+    execution_identifier: executionIdentifier,
+    result: 'result',
+    error,
+});
+
+const buildPendingRun = (options?: {
+    priorFailedTurns?: number;
+    priorToolName?: string;
+    pendingToolName?: string;
+}): {
+    existingTurns: TSelectableTurn[];
+    existingBlocks: TSelectableBlock[];
+    pendingExecutionIdentifier: string;
+} => {
+    const priorFailedTurns = options?.priorFailedTurns ?? 0;
+    const priorToolName = options?.priorToolName ?? 'write_and_run_js';
+    const pendingToolName = options?.pendingToolName ?? priorToolName;
+
+    let createdAtMs = 1;
+    const existingTurns: TSelectableTurn[] = [];
+    const existingBlocks: TSelectableBlock[] = [];
+
+    existingTurns.push(makeTurn('user-0', 'user', createdAtMs++));
+    existingBlocks.push(
+        makeTextBlock('block-text-0', 'user-0', 'Help me', createdAtMs++),
+    );
+
+    for (let i = 1; i <= priorFailedTurns; i++) {
+        const executionIdentifier = `execution-${i}`;
+        const assistantTurnId = `assistant-${i}`;
+        const userTurnId = `user-${i}`;
+
+        existingTurns.push(makeTurn(assistantTurnId, 'assistant', createdAtMs++));
+        existingBlocks.push(
+            makeToolUseBlock(
+                `block-tool-use-${i}`,
+                assistantTurnId,
+                executionIdentifier,
+                priorToolName,
+                createdAtMs++,
+            ),
+        );
+
+        existingTurns.push(makeTurn(userTurnId, 'user', createdAtMs++));
+        existingBlocks.push(
+            makeToolResultBlock(
+                `block-tool-result-${i}`,
+                userTurnId,
+                executionIdentifier,
+                `error-${i}`,
+                createdAtMs++,
+            ),
+        );
+    }
+
+    const pendingExecutionIdentifier = `execution-${priorFailedTurns + 1}`;
+    const pendingAssistantTurnId = `assistant-${priorFailedTurns + 1}`;
+    existingTurns.push(
+        makeTurn(pendingAssistantTurnId, 'assistant', createdAtMs++),
+    );
+    existingBlocks.push(
+        makeToolUseBlock(
+            `block-tool-use-${priorFailedTurns + 1}`,
+            pendingAssistantTurnId,
+            pendingExecutionIdentifier,
+            pendingToolName,
+            createdAtMs++,
+        ),
+    );
+
+    return {existingTurns, existingBlocks, pendingExecutionIdentifier};
+};
+
+describe('loop controls', () => {
+    test('failed execution turns increment across consecutive failing follow-up turns', () => {
+        const {existingTurns, existingBlocks, pendingExecutionIdentifier} =
+            buildPendingRun({priorFailedTurns: 1});
+        const runSegment = getRunSegmentSinceLastTrueUserTurn(
+            false,
+            existingTurns,
+            existingBlocks,
+        );
+
+        const budget = countConsecutiveFailedExecutionTurns(
+            runSegment.turns,
+            runSegment.blocks,
+            [makeExecutionResult(pendingExecutionIdentifier, 'boom')],
+        );
+
+        expect(budget.failedExecutionTurnCount).toBe(2);
+        expect(budget.turnsRemaining).toBe(4);
+        expect(budget.isForceStop).toBe(false);
+    });
+
+    test('any successful execution result resets the failed execution turn streak', () => {
+        const {existingTurns, existingBlocks, pendingExecutionIdentifier} =
+            buildPendingRun({priorFailedTurns: 3});
+        const runSegment = getRunSegmentSinceLastTrueUserTurn(
+            false,
+            existingTurns,
+            existingBlocks,
+        );
+
+        const budget = countConsecutiveFailedExecutionTurns(
+            runSegment.turns,
+            runSegment.blocks,
+            [makeExecutionResult(pendingExecutionIdentifier, null)],
+        );
+
+        expect(budget.failedExecutionTurnCount).toBe(0);
+        expect(budget.turnsRemaining).toBe(6);
+        expect(budget.isForceStop).toBe(false);
+    });
+
+    test('a new true user turn resets the run segment and all streaks', () => {
+        const {existingTurns, existingBlocks} = buildPendingRun({
+            priorFailedTurns: 2,
+        });
+        const runSegment = getRunSegmentSinceLastTrueUserTurn(
+            true,
+            existingTurns,
+            existingBlocks,
+        );
+
+        const budget = countConsecutiveFailedExecutionTurns(
+            runSegment.turns,
+            runSegment.blocks,
+            [{type: 'text', message: 'Try something else'}],
+        );
+
+        expect(runSegment.turns).toEqual([]);
+        expect(runSegment.blocks).toEqual([]);
+        expect(budget.failedExecutionTurnCount).toBe(0);
+        expect(budget.turnsRemaining).toBe(6);
+        expect(budget.isForceStop).toBe(false);
+    });
+
+    test('failed execution turn stop triggers on the exact threshold call', () => {
+        const {existingTurns, existingBlocks, pendingExecutionIdentifier} =
+            buildPendingRun({priorFailedTurns: 5});
+        const runSegment = getRunSegmentSinceLastTrueUserTurn(
+            false,
+            existingTurns,
+            existingBlocks,
+        );
+
+        const budget = countConsecutiveFailedExecutionTurns(
+            runSegment.turns,
+            runSegment.blocks,
+            [makeExecutionResult(pendingExecutionIdentifier, 'boom')],
+        );
+
+        expect(budget.failedExecutionTurnCount).toBe(MAX_CONSECUTIVE_FAILED_EXECUTION_TURNS);
+        expect(budget.turnsRemaining).toBe(0);
+        expect(budget.isForceStop).toBe(true);
+    });
+
+    test('the large agent turn backstop still trips independently', () => {
+        const {existingTurns, existingBlocks} = buildPendingRun({
+            priorFailedTurns: 19,
+        });
+        const runSegment = getRunSegmentSinceLastTrueUserTurn(
+            false,
+            existingTurns,
+            existingBlocks,
+        );
+
+        const budget = countAgentTurnsSinceLastUserTurn(runSegment.turns);
+
+        expect(budget.agentTurnCount).toBe(MAX_AGENT_TURNS);
+        expect(budget.turnsRemaining).toBe(0);
+        expect(budget.isForceStop).toBe(true);
+    });
+
+    test('edit failures are counted on the exact call that receives the latest failed result', () => {
+        const {existingTurns, existingBlocks, pendingExecutionIdentifier} =
+            buildPendingRun({
+                priorFailedTurns: 2,
+                priorToolName: 'edit_and_run_js',
+                pendingToolName: 'edit_and_run_js',
+            });
+        const runSegment = getRunSegmentSinceLastTrueUserTurn(
+            false,
+            existingTurns,
+            existingBlocks,
+        );
+
+        const editFailures = countConsecutiveEditFailures(runSegment.blocks, [
+            makeExecutionResult(pendingExecutionIdentifier, 'boom'),
+        ]);
+
+        expect(editFailures).toBe(MAX_CONSECUTIVE_EDIT_FAILURES);
+    });
+
+    test('a successful tool run resets the edit failure streak', () => {
+        const {existingTurns, existingBlocks, pendingExecutionIdentifier} =
+            buildPendingRun({
+                priorFailedTurns: 2,
+                priorToolName: 'edit_and_run_js',
+                pendingToolName: 'edit_and_run_js',
+            });
+        const runSegment = getRunSegmentSinceLastTrueUserTurn(
+            false,
+            existingTurns,
+            existingBlocks,
+        );
+
+        const editFailures = countConsecutiveEditFailures(runSegment.blocks, [
+            makeExecutionResult(pendingExecutionIdentifier, null),
+        ]);
+
+        expect(editFailures).toBe(0);
+    });
+
+    test('the edit failure guard stays narrow and ignores non-edit failures', () => {
+        const {existingTurns, existingBlocks, pendingExecutionIdentifier} =
+            buildPendingRun({
+                priorFailedTurns: 2,
+                priorToolName: 'edit_and_run_js',
+                pendingToolName: 'write_and_run_js',
+            });
+        const runSegment = getRunSegmentSinceLastTrueUserTurn(
+            false,
+            existingTurns,
+            existingBlocks,
+        );
+
+        const editFailures = countConsecutiveEditFailures(runSegment.blocks, [
+            makeExecutionResult(pendingExecutionIdentifier, 'boom'),
+        ]);
+
+        expect(editFailures).toBe(0);
+    });
+
+    test('force stop appends the apology instruction without dropping tool results', () => {
+        const messages: MessageParam[] = [
+            {
+                role: 'assistant',
+                content: [
+                    {
+                        type: 'tool_use',
+                        id: 'execution-1',
+                        name: 'retrying',
+                        input: {js_code: 'await retry()'},
+                    },
+                ],
+            },
+            {
+                role: 'user',
+                content: [
+                    {
+                        type: 'tool_result',
+                        tool_use_id: 'execution-1',
+                        content: 'result\n--- ERROR ---\nboom',
+                        is_error: true,
+                    },
+                ],
+            },
+        ];
+
+        applyForceStop(messages, 'failed_execution_turns');
+
+        expect(messages[0]).toMatchObject({
+            role: 'assistant',
+            content: [{type: 'tool_use', id: 'execution-1'}],
+        });
+        expect(messages[1].role).toBe('user');
+        expect(Array.isArray(messages[1].content)).toBe(true);
+        expect(messages[1].content).toMatchObject([
+            {type: 'tool_result', tool_use_id: 'execution-1'},
+            {type: 'text'},
+        ]);
+        expect(messages[1].content).toContainEqual(
+            expect.objectContaining({
+                type: 'text',
+                text: expect.stringContaining(
+                    'consecutive failed execution turns',
+                ),
+            }),
+        );
+    });
+
+    test('agent turn backstop force stop uses the total turn limit instruction', () => {
+        const messages: MessageParam[] = [
+            {
+                role: 'user',
+                content: [{type: 'text', text: 'Current results'}],
+            },
+        ];
+
+        applyForceStop(messages, 'max_agent_turns');
+
+        expect(messages[0].content).toContainEqual(
+            expect.objectContaining({
+                type: 'text',
+                text: expect.stringContaining('total execution turns'),
+            }),
+        );
+    });
+});

--- a/apps/core/src/trpc/routers/converse/messages.mts
+++ b/apps/core/src/trpc/routers/converse/messages.mts
@@ -5,7 +5,10 @@ import type {
 } from '@anthropic-ai/sdk/resources/messages';
 import type {TSelectableBlock, TSelectableTurn} from '#core/db/types.mjs';
 import type {TUserBlock} from './schemas.mjs';
-import {MAX_AGENT_TURNS} from './schemas.mjs';
+import {
+    MAX_AGENT_TURNS,
+    MAX_CONSECUTIVE_FAILED_EXECUTION_TURNS,
+} from './schemas.mjs';
 
 // ── User Content ────────────────────────────────────────────
 
@@ -184,30 +187,55 @@ export const markLastMessageForCaching = (
 
 // ── Force Stop ──────────────────────────────────────────────
 
-export const applyForceStop = (messages: MessageParam[]): void => {
-    const lastAssistantIdx = messages.findLastIndex(
-        (m) => m.role === 'assistant',
-    );
-    if (lastAssistantIdx !== -1) {
-        messages[lastAssistantIdx] = {
-            role: 'assistant',
-            content: [
-                {
-                    type: 'text',
-                    text: 'I have used all of my available execution turns.',
-                },
-            ],
-        };
+export type TForceStopReason =
+    | 'failed_execution_turns'
+    | 'max_agent_turns';
+
+const buildForceStopInstruction = (reason: TForceStopReason): string =>
+    reason === 'failed_execution_turns'
+        ? `You have reached the limit of ${MAX_CONSECUTIVE_FAILED_EXECUTION_TURNS} consecutive failed execution turns without a successful run. Respond with ONLY a text message apologizing to the user. Briefly summarize what you accomplished and explain that repeated execution failures prevented you from completing the request.`
+        : `You have used all ${MAX_AGENT_TURNS} of your total execution turns. Respond with ONLY a text message apologizing to the user. Briefly summarize what you accomplished and explain that you could not complete the request within the total turn limit.`;
+
+export const applyForceStop = (
+    messages: MessageParam[],
+    reason: TForceStopReason,
+): void => {
+    const lastUserIdx = messages.length - 1;
+    const instructionBlock = {
+        type: 'text' as const,
+        text: buildForceStopInstruction(reason),
+    };
+
+    const lastUserMessage = messages[lastUserIdx];
+    if (!lastUserMessage) {
+        messages.push({
+            role: 'user',
+            content: [instructionBlock],
+        });
+        return;
     }
 
-    const lastUserIdx = messages.length - 1;
+    if (typeof lastUserMessage.content === 'string') {
+        messages[lastUserIdx] = {
+            role: 'user',
+            content: [
+                {type: 'text' as const, text: lastUserMessage.content},
+                instructionBlock,
+            ],
+        };
+        return;
+    }
+
+    if (!Array.isArray(lastUserMessage.content)) {
+        messages[lastUserIdx] = {
+            role: 'user',
+            content: [instructionBlock],
+        };
+        return;
+    }
+
     messages[lastUserIdx] = {
         role: 'user',
-        content: [
-            {
-                type: 'text',
-                text: `You have used all ${MAX_AGENT_TURNS} of your execution turns. Respond with ONLY a text message apologizing to the user. Briefly summarize what you accomplished and explain that you could not complete the request within the turn limit.`,
-            },
-        ],
+        content: [...lastUserMessage.content, instructionBlock],
     };
 };

--- a/apps/core/src/trpc/routers/converse/schemas.mts
+++ b/apps/core/src/trpc/routers/converse/schemas.mts
@@ -39,7 +39,9 @@ export const API_MODEL = 'claude-sonnet-4-20250514';
 export const DB_MODEL: TConversationModel = 'claude-sonnet-4.6';
 export const MAX_TOKENS = 16384;
 export const MAX_CONSECUTIVE_EDIT_FAILURES = 3;
-export const MAX_AGENT_TURNS = 6;
+export const MAX_CONSECUTIVE_FAILED_EXECUTION_TURNS = 6;
+// TODO: Move MAX_AGENT_TURNS to env vars once loop controls settle.
+export const MAX_AGENT_TURNS = 30;
 
 // ── Anthropic Tool Definitions ──────────────────────────────
 


### PR DESCRIPTION
- Kept total agent turns max limit, but increased it to 20
- Kept the edit limit because my understanding is it forces a fresh rewrite after that limit, not just stop agent turns
- Added required error retry limit at 6